### PR TITLE
Theme overrides for the MUI Chip for Pills and Badges components

### DIFF
--- a/docs/src/components/Pill.stories.tsx
+++ b/docs/src/components/Pill.stories.tsx
@@ -1,0 +1,86 @@
+import { action } from '@storybook/addon-actions';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Pill as PillComponent } from '@ui-kit-2022/components';
+import { Icon } from '@ui-kit-2022/components';
+import * as React from 'react';
+
+const ICON_NAMES = Object.keys(Icon);
+const ICON_MAPPINGS = Object.fromEntries(
+  Object.entries(Icon).map(([k, v]) => [k, React.createElement(v)]),
+);
+
+export default {
+  title: 'Components/Pill',
+  component: PillComponent,
+  argTypes: {
+    label: {
+      name: 'Label',
+      type: { name: 'string', required: true },
+      defaultValue: 'Label',
+    },
+    variant: {
+      name: 'Variant',
+      control: 'inline-radio',
+      options: ['filled', 'outlined'],
+      defaultValue: 'filled',
+    },
+    color: {
+      name: 'Color',
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'success', 'warning'],
+      defaultValue: 'primary',
+    },
+    disabled: {
+      name: 'Disabled',
+      control: 'boolean',
+      defaultValue: false,
+    },
+    ticker: {
+      name: 'Ticker',
+      description: 'Enable if this pill is intended to be used as a stock ticker',
+      control: 'boolean',
+      defaultValue: false,
+    },
+    icon: {
+      name: 'Icon',
+      description: 'The left aligned icon.',
+      control: 'select',
+      options: ICON_NAMES,
+      mapping: ICON_MAPPINGS,
+    },
+    rightIcon: {
+      name: 'Right Icon',
+      description: 'The right aligned icon.',
+      control: 'select',
+      if: { arg: 'onClickIcon' },
+      options: ICON_NAMES,
+      mapping: ICON_MAPPINGS,
+    },
+    onClick: {
+      name: 'Enable On Click',
+      description: 'Adds an onClick handler, which enables basic button functionality.',
+      control: 'boolean',
+      defaultValue: false,
+      mapping: {
+        true: action('click'),
+        false: undefined,
+      },
+    },
+    onClickIcon: {
+      name: 'Enable On Click Icon',
+      description: 'Adds an onClickIcon handler, which displays the right icon.',
+      control: 'boolean',
+      defaultValue: false,
+      mapping: {
+        true: action('click-icon'),
+        false: undefined,
+      },
+    },
+  },
+} as ComponentMeta<typeof PillComponent>;
+
+const Template: ComponentStory<typeof PillComponent> = (args: any) => {
+  return <PillComponent {...args} />;
+};
+
+export const Pill = Template.bind({});

--- a/docs/src/components/mui/Button.stories.tsx
+++ b/docs/src/components/mui/Button.stories.tsx
@@ -1,0 +1,61 @@
+import { Button as MuiButton, ButtonProps } from '@mui/material';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Icon } from '@ui-kit-2022/components';
+import * as React from 'react';
+
+const ICON_NAMES = Object.keys(Icon);
+const ICON_MAPPINGS = Object.fromEntries(
+  Object.entries(Icon).map(([k, v]) => [k, React.createElement(v)]),
+);
+
+export default {
+  title: 'Material UI/Button',
+  component: MuiButton,
+  argTypes: {
+    children: {
+      name: 'Text',
+      type: { name: 'string', required: true },
+      defaultValue: 'Label',
+    },
+    variant: {
+      name: 'Variant',
+      control: 'radio',
+      options: ['text', 'contained', 'outlined'],
+      defaultValue: 'text',
+    },
+    color: {
+      name: 'Color',
+      control: 'select',
+      options: ['primary', 'secondary', 'error', 'info', 'success', 'warning'],
+      defaultValue: 'primary',
+    },
+    disabled: {
+      name: 'Disabled',
+      control: 'boolean',
+      defaultValue: false,
+    },
+    startIcon: {
+      name: 'Start Icon',
+      description: 'The left aligned icon.',
+      control: 'select',
+      options: ICON_NAMES,
+      mapping: ICON_MAPPINGS,
+    },
+    endIcon: {
+      name: 'End Icon',
+      description: 'The right aligned icon.',
+      control: 'select',
+      options: ICON_NAMES,
+      mapping: ICON_MAPPINGS,
+    },
+  },
+} as ComponentMeta<typeof MuiButton>;
+
+const Template: ComponentStory<typeof MuiButton> = ({
+  children,
+  ...args
+}: ButtonProps) => {
+  return <MuiButton {...args}>{children}</MuiButton>;
+};
+
+export const Button = Template.bind({});

--- a/docs/src/components/mui/Chip.stories.tsx
+++ b/docs/src/components/mui/Chip.stories.tsx
@@ -1,0 +1,80 @@
+import { Chip as MuiChip } from '@mui/material';
+import { action } from '@storybook/addon-actions';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { Icon } from '@ui-kit-2022/components';
+import * as React from 'react';
+
+const ICON_NAMES = Object.keys(Icon);
+const ICON_MAPPINGS = Object.fromEntries(
+  Object.entries(Icon).map(([k, v]) => [k, React.createElement(v)]),
+);
+
+export default {
+  title: 'Material UI/Chip',
+  component: MuiChip,
+  argTypes: {
+    label: {
+      name: 'Label',
+      type: { name: 'string', required: true },
+      defaultValue: 'Label',
+    },
+    variant: {
+      name: 'Variant',
+      control: 'inline-radio',
+      options: ['filled', 'outlined'],
+      defaultValue: 'filled',
+    },
+    color: {
+      name: 'Color',
+      control: 'select',
+      options: ['default', 'primary', 'secondary', 'error', 'info', 'success', 'warning'],
+      defaultValue: 'default',
+    },
+    disabled: {
+      name: 'Disabled',
+      control: 'boolean',
+      defaultValue: false,
+    },
+    icon: {
+      name: 'Icon',
+      description: 'The left aligned icon.',
+      control: 'select',
+      options: ICON_NAMES,
+      mapping: ICON_MAPPINGS,
+    },
+    deleteIcon: {
+      name: 'Delete Icon',
+      description: 'The right aligned icon.',
+      control: 'select',
+      if: { arg: 'onDelete' },
+      options: ICON_NAMES,
+      mapping: ICON_MAPPINGS,
+    },
+    onClick: {
+      name: 'Enable On Click',
+      description: 'Adds an onClick handler, which enables basic button functionality.',
+      control: 'boolean',
+      defaultValue: false,
+      mapping: {
+        true: action('click'),
+        false: undefined,
+      },
+    },
+    onDelete: {
+      name: 'Enable On Delete',
+      description: 'Adds an onDelete handler, which displays the right (delete) icon.',
+      control: 'boolean',
+      defaultValue: false,
+      mapping: {
+        true: action('delete'),
+        false: undefined,
+      },
+    },
+  },
+} as ComponentMeta<typeof MuiChip>;
+
+const Template: ComponentStory<typeof MuiChip> = (args: any) => {
+  return <MuiChip {...args} />;
+};
+
+export const Chip = Template.bind({});

--- a/packages/ui-kit-components/src/components/Pill/Pill.tsx
+++ b/packages/ui-kit-components/src/components/Pill/Pill.tsx
@@ -1,0 +1,28 @@
+import { Chip } from '@mui/material';
+import * as React from 'react';
+
+export type PillVariants = 'filled' | 'outlined';
+
+export interface PillProps {
+  label: string;
+  variant?: any;
+  ticker?: boolean;
+  disabled?: boolean;
+  icon?: JSX.Element;
+  rightIcon?: JSX.Element;
+  onClick?: React.MouseEventHandler<HTMLElement>;
+  onClickIcon?: React.MouseEventHandler<HTMLElement>;
+}
+
+const Pill: React.FC<PillProps> = ({ rightIcon, onClickIcon, ticker, ...props }) => (
+  <Chip
+    {...props}
+    deleteIcon={rightIcon}
+    onDelete={onClickIcon}
+    sx={{
+      ...(ticker && { width: '64px' }),
+    }}
+  />
+);
+
+export default Pill;

--- a/packages/ui-kit-components/src/components/Pill/index.ts
+++ b/packages/ui-kit-components/src/components/Pill/index.ts
@@ -1,0 +1,1 @@
+export { default as Pill } from './Pill';

--- a/packages/ui-kit-components/src/index.ts
+++ b/packages/ui-kit-components/src/index.ts
@@ -5,5 +5,6 @@ export { LogoBrand } from './components/Branding/LogoBrand';
 export { LogoText } from './components/Branding/LogoText';
 export * as BrandIcon from './components/Branding/raw-icons';
 export { Button } from './components/Button';
+export { Pill } from './components/Pill';
 export { Typography } from './components/Typography';
 export * as Icon from './icons';

--- a/packages/ui-kit-theme/src/overrides/MuiButtonBase.ts
+++ b/packages/ui-kit-theme/src/overrides/MuiButtonBase.ts
@@ -1,0 +1,17 @@
+export default {
+  styleOverrides: {
+    root: ({ theme }: any) => ({
+      '&:active': {
+        outline: 'none !important',
+      },
+      '&:focus': {
+        outline: `2px solid ${
+          theme.palette.mode === 'light'
+            ? theme.palette.warning.main
+            : theme.palette.warning.light
+        }`,
+        outlineOffset: '2px',
+      },
+    }),
+  },
+};

--- a/packages/ui-kit-theme/src/overrides/MuiChip.ts
+++ b/packages/ui-kit-theme/src/overrides/MuiChip.ts
@@ -1,0 +1,118 @@
+import { alpha } from '@mui/material';
+
+export default {
+  defaultProps: {
+    size: 'small',
+    disableRipple: true,
+  },
+  styleOverrides: {
+    root: ({ theme, ownerState }: any) => ({
+      fontSize: theme.typography.button.fontSize,
+      fontFamily: theme.typography.button.fontSize,
+      fontWeight: theme.typography.button.fontWeight,
+
+      textTransform: 'uppercase',
+      height: 'auto',
+      borderRadius: '8px',
+
+      // Material UI has action palettes that augment colors based on the action
+      // If the designers will support it, it can be used instead
+      '&.MuiButtonBase-root:active, &.MuiButtonBase-root:hover': {
+        boxShadow: 'none',
+
+        // Border color transitions to the opposite color variation from the theme on active and hover
+        ...(ownerState.color !== 'default' && {
+          borderColor:
+            theme.palette[ownerState.color][
+              theme.palette.mode === 'light' ? 'dark' : 'light'
+            ],
+        }),
+      },
+      /*
+       * Should the focus outline be enabled or disabled when only the onDelete event is attached?
+      ...(ownerState.onDelete && !ownerState.onClick && {
+        '&:focus': {
+          outline: 'none'
+        }
+      })
+      */
+    }),
+    filled: ({ theme, ownerState }: any) => ({
+      // Ensures smooth border transition when entering active state.
+      border: '1px solid transparent',
+      ...(ownerState.color !== 'default' &&
+        (theme.palette.mode === 'light'
+          ? {
+              '&.MuiButtonBase-root:hover': {
+                // Color changes to white on hover in light mode
+                color: alpha(theme.palette.common.white, 0.95),
+                // Background color darkens on hover in light mode
+                backgroundColor: theme.palette[ownerState.color].dark,
+              },
+              '&.MuiButtonBase-root:active': {
+                // Changes back to the primary text color
+                color: `${theme.palette.text.primary} !important`,
+                // Changes background color back to main
+                backgroundColor: theme.palette[ownerState.color].main,
+              },
+            }
+          : {
+              '&.MuiButtonBase-root:hover': {
+                backgroundColor: `${theme.palette[ownerState.color].light}`,
+              },
+              '&.MuiButtonBase-root:active': {
+                backgroundColor: theme.palette[ownerState.color].main,
+              },
+            })),
+    }),
+    outlined: ({ theme, ownerState }: any) => ({
+      ...(ownerState.color !== 'default' &&
+        (theme.palette.mode === 'light'
+          ? {
+              // Border color is always primary for outlined variant in light mode
+              color: theme.palette.text.primary,
+            }
+          : {
+              // Ensure text color is set to the primary text color when Chip color is not primary
+              ...(ownerState.color !== 'primary' && {
+                color: theme.palette.text.primary,
+              }),
+              // In dark mode, the text color lightens on hover
+              '&.MuiButtonBase-root:hover': {
+                color: theme.palette[ownerState.color]['light'],
+              },
+              // In dark mode, when in an active state, the text color dims back to normal
+              '&.MuiButtonBase-root:active': {
+                color: `${theme.palette[ownerState.color]['main']} !important`,
+              },
+            })),
+    }),
+    // Make label color accessible for Error and Secondary colors
+    colorError: ({ theme, ownerState }: any) => ({
+      ...(ownerState.variant === 'filled' && {
+        color: alpha(theme.palette.common.black, 0.95),
+      }),
+    }),
+    colorSecondary: ({ theme, ownerState }: any) => ({
+      ...(ownerState.variant === 'filled' && {
+        color: alpha(theme.palette.common.black, 0.95),
+      }),
+    }),
+    label: {
+      lineHeight: '13px',
+      padding: '4px',
+    },
+    icon: {
+      width: '16px',
+      height: '16px',
+    },
+    deleteIcon: ({ theme }: any) => ({
+      width: '16px',
+      height: '16px',
+      color: 'inherit !important',
+      // This icon can be clicked.
+      // Do the hover state colors for this prop need to be overriden to reflect that?
+      //'&:hover': theme.palette.text.primary
+    }),
+  },
+};

--- a/packages/ui-kit-theme/src/overrides/index.ts
+++ b/packages/ui-kit-theme/src/overrides/index.ts
@@ -1,12 +1,19 @@
 import { DARK_BUTTON, LIGHT_BUTTON } from './MuiButton';
+import MuiButtonBase from './MuiButtonBase';
+import MuiChip from './MuiChip';
 import MuiDivider from './MuiDivider';
+
 // Component overrides
 export const LIGHT_COMPONENTS = {
+  MuiButtonBase,
   MuiDivider,
+  MuiChip,
   MuiButton: LIGHT_BUTTON,
 };
 
 export const DARK_COMPONENTS = {
+  MuiButtonBase,
   MuiDivider,
+  MuiChip,
   MuiButton: DARK_BUTTON,
 };


### PR DESCRIPTION
There's so much overlap between the Pills and Button components, that these theme overrides can likely be shared between the two. The Button could be refactored to set the overrides, and then the MUI Button can be used for many of the Button and Pills use cases.