### PR TITLE
Set correct chromatic workflow directory

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: docs


### PR DESCRIPTION
This is a fix to set the proper working directory for the Chromatic build.