### PR TITLE
Add light mode for Typography styles and types pages

### DIFF
--- a/docs/.storybook/preview.tsx
+++ b/docs/.storybook/preview.tsx
@@ -30,7 +30,7 @@ export const parameters = {
       ...themes.dark,
       ...themeDefaults,
       appBg: '#323232',
-      appContentBg: '#383838',
+      appContentBg: '#323232',
       brandImage: 'brand-logo.light.svg',
     },
     // Override the default light theme
@@ -54,7 +54,7 @@ export const decorators = [
       padding: '1rem',
       width: '100%',
       height: '100%',
-      backgroundColor: `${isDarkMode ? '#383838' : '#F9F9F9'}`,
+      backgroundColor: `${isDarkMode ? '#323232' : '#F9F9F9'}`,
     }));
 
     return (

--- a/docs/src/design-system/building-blocks/common/top-bar.tsx
+++ b/docs/src/design-system/building-blocks/common/top-bar.tsx
@@ -12,12 +12,13 @@ const TopBar: React.FC<Props> = ({ icon, title }) => {
     <Box
       sx={{
         height: '68px',
-        bgcolor: palette.grey['700'],
+        backgroundColor: { dark: palette.grey['700'], light: palette.grey['200'] }[
+          palette.mode
+        ],
         display: 'flex',
         alignItems: 'center',
         padding: '0px 1rem',
         justifyContent: 'flex-start',
-        color: palette.common.white,
       }}
     >
       {icon && (
@@ -27,7 +28,7 @@ const TopBar: React.FC<Props> = ({ icon, title }) => {
           sx={{ width: '34px', height: '34px' }}
         />
       )}
-      <Typography sx={{ color: palette.common.white, marginLeft: '1rem' }}>
+      <Typography variant="h1" sx={{ marginLeft: '1rem' }}>
         {title}
       </Typography>
     </Box>

--- a/docs/src/design-system/building-blocks/typography/font-example.tsx
+++ b/docs/src/design-system/building-blocks/typography/font-example.tsx
@@ -25,13 +25,11 @@ function getFontWeightAndFontStyle(s: fontOption): FontWeightAndStyle {
 
 const FontExample: React.FC<ExampleProps> = ({ title, content }) => {
   return (
-    <Box sx={{ bgcolor: '#323232', maxHeight: '120px' }}>
-      <Typography
-        sx={{ fontSize: '20px', color: '#F2F2F2', ...getFontWeightAndFontStyle(title) }}
-      >
+    <Box sx={{ maxHeight: '120px' }}>
+      <Typography sx={{ fontSize: '20px', ...getFontWeightAndFontStyle(title) }}>
         {title}
       </Typography>
-      <Typography sx={{ fontSize: '20px', color: '#F2F2F2' }}>{content}</Typography>
+      <Typography sx={{ fontSize: '20px' }}>{content}</Typography>
     </Box>
   );
 };

--- a/docs/src/design-system/building-blocks/typography/font-examples.tsx
+++ b/docs/src/design-system/building-blocks/typography/font-examples.tsx
@@ -11,7 +11,6 @@ const FontExamplesContainer: React.FC<FontExamplesContainerProps> = ({ children 
   <Grid
     container
     sx={{
-      bgcolor: '#323232',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'flex-start',
@@ -25,19 +24,19 @@ const FontExamplesContainer: React.FC<FontExamplesContainerProps> = ({ children 
 const MerriweatherExamples = () => (
   <>
     <Grid item xs={1.5}>
-      <Typography sx={{ color: '#F2F2F2', fontSize: '20px' }}>13px</Typography>
+      <Typography sx={{ fontSize: '20px' }}>13px</Typography>
     </Grid>
     <Grid item xs={10.5}>
       <FontExample title={'Light Italic'} content={'Sidepanel text'} />
     </Grid>
     <Grid item xs={1.5}>
-      <Typography sx={{ color: '#F2F2F2', fontSize: '20px' }}>16px</Typography>
+      <Typography sx={{ fontSize: '20px' }}>16px</Typography>
     </Grid>
     <Grid item xs={10.5}>
       <FontExample title={'Regular'} content={'Subitles'} />
     </Grid>
     <Grid item xs={1.5}>
-      <Typography sx={{ color: '#F2F2F2', fontSize: '20px' }}>32px</Typography>
+      <Typography sx={{ fontSize: '20px' }}>32px</Typography>
     </Grid>
     <Grid item xs={10.5}>
       <FontExample title={'Regular'} content={'Titles'} />
@@ -48,7 +47,7 @@ const MerriweatherExamples = () => (
 const RobotoExamples = () => (
   <>
     <Grid item lg={1.5} xs={2}>
-      <Typography sx={{ color: '#F2F2F2', fontSize: '20px' }}>11px</Typography>
+      <Typography sx={{ fontSize: '20px' }}>11px</Typography>
     </Grid>
     <Grid item lg={3.5} xs={5}>
       <FontExample title={'Light Italic'} content={'Miscellaneous {ex: time stamps}'} />
@@ -57,7 +56,7 @@ const RobotoExamples = () => (
       <FontExample title={'Medium'} content={'Chips'} />
     </Grid>
     <Grid item lg={1.5} xs={2}>
-      <Typography sx={{ color: '#F2F2F2', fontSize: '20px' }}>12px</Typography>
+      <Typography sx={{ fontSize: '20px' }}>12px</Typography>
     </Grid>
     <Grid item lg={3.5} xs={5}>
       <FontExample title={'Regular'} content={'Statistic values | table inputs'} />
@@ -66,7 +65,7 @@ const RobotoExamples = () => (
       <FontExample title={'Medium'} content={'Statistic titles'} />
     </Grid>
     <Grid item lg={1.5} xs={2}>
-      <Typography sx={{ color: '#F2F2F2', fontSize: '20px' }}>16px</Typography>
+      <Typography sx={{ fontSize: '20px' }}>16px</Typography>
     </Grid>
     <Grid item lg={10.5} xs={10}>
       <FontExample title={'Regular'} content={'Dropdown results'} />

--- a/docs/src/design-system/building-blocks/typography/text-sample.tsx
+++ b/docs/src/design-system/building-blocks/typography/text-sample.tsx
@@ -10,8 +10,8 @@ export interface TextSampleProps {
 
 const TextSample: React.FC<TextSampleProps> = ({ fontName }) => {
   return (
-    <Box sx={{ bgcolor: '#323232' }}>
-      <Typography sx={{ color: '#FFFFFF', fontSize: '24px', marginBottom: '10px' }}>
+    <Box>
+      <Typography sx={{ fontSize: '24px', marginBottom: '10px' }}>
         {fontName.toUpperCase()}
       </Typography>
       <Typography

--- a/docs/src/design-system/building-blocks/typography/type-card.tsx
+++ b/docs/src/design-system/building-blocks/typography/type-card.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, styled, Typography } from '@mui/material';
+import { Card, CardContent, styled, Typography, useTheme } from '@mui/material';
 import * as React from 'react';
 
 export interface TypeCardProps {
@@ -13,19 +13,25 @@ type StyledCardProps = Pick<TypeCardProps, 'fontFamily'>;
 const StyledCard = styled(Card)<StyledCardProps>`
   width: 132px;
   height: 125px;
-  background-color: #555555;
 `;
 
 const TypeCard: React.FC<TypeCardProps> = ({ title, letter, fontFamily, fontWeight }) => {
+  const { palette } = useTheme();
   return (
-    <StyledCard fontFamily={fontFamily}>
+    <StyledCard
+      fontFamily={fontFamily}
+      sx={{
+        backgroundColor: { dark: palette.grey.A700, light: palette.grey.A200 }[
+          palette.mode
+        ],
+      }}
+    >
       <CardContent>
         <Typography sx={{ fontSize: '12px', color: '#BBBBBB' }}>{title}</Typography>
         <Typography
           component="div"
           sx={{
             fontSize: '50px',
-            color: '#FFFFFF',
             textAlign: 'center',
             fontWeight: `${fontWeight}`,
             fontFamily: `${fontFamily}`,

--- a/docs/src/design-system/typography/TextStylesPage.tsx
+++ b/docs/src/design-system/typography/TextStylesPage.tsx
@@ -39,8 +39,7 @@ const tableCellStyles = (palette: Palette) => {
     width: '7.625rem',
     height: '2.5rem',
     padding: 0,
-    color: palette.common.white,
-    borderColor: palette.grey['600'],
+    borderColor: { dark: palette.grey['600'], light: palette.grey['200'] }[palette.mode],
   };
 };
 const tableColumns: string[] = [
@@ -55,12 +54,7 @@ const tableColumns: string[] = [
 const TextStylesPage: React.FC = () => {
   const { palette } = useTheme();
   return (
-    <Grid
-      container
-      sx={{
-        bgcolor: palette.mode === 'dark' ? palette.background.paper : palette.logo,
-      }}
-    >
+    <Grid container>
       <Grid item xs={12}>
         <TopBar title={'STYLE'} />
       </Grid>
@@ -98,8 +92,10 @@ const TextStylesPage: React.FC = () => {
                   scope="row"
                   sx={{
                     padding: 0,
-                    color: palette.common.white,
-                    borderColor: palette.grey['600'],
+                    borderColor: {
+                      dark: palette.grey['600'],
+                      light: palette.grey['200'],
+                    }[palette.mode],
                   }}
                 >
                   <Typography variant={row.category.toLowerCase() as any}>

--- a/docs/src/design-system/typography/types-page.tsx
+++ b/docs/src/design-system/typography/types-page.tsx
@@ -34,12 +34,7 @@ const TYPE_CARD_REGULAR_MERRIWEATHER_PROPS = {
 const TypesPage: React.FC = () => {
   const { palette } = useTheme();
   return (
-    <Grid
-      container
-      sx={{
-        bgcolor: palette.mode === 'dark' ? palette.background.paper : palette.logo,
-      }}
-    >
+    <Grid container>
       <Grid item xs={12}>
         <TopBar title={'TYPES'} />
       </Grid>
@@ -61,7 +56,7 @@ const TypesPage: React.FC = () => {
           <TypeCard {...TYPE_CARD_LIGHT_ITALIC_PROPS} />
         </Grid>
         <Grid item md={12} xs={12}>
-          <Typography sx={{ color: palette.common.white }}>Examples</Typography>
+          <Typography>Examples</Typography>
         </Grid>
         <Grid item xs={12}>
           <FontExamples fontName={ROBOTO} />
@@ -82,7 +77,7 @@ const TypesPage: React.FC = () => {
           <TypeCard {...TYPE_CARD_REGULAR_MERRIWEATHER_PROPS} />
         </Grid>
         <Grid item xs={12}>
-          <Typography sx={{ color: palette.common.white }}>Examples</Typography>
+          <Typography>Examples</Typography>
         </Grid>
         <Grid item xs={12}>
           <FontExamples fontName={MERRIWEATHER} />


### PR DESCRIPTION
Based on my test, we have already set  different background colors and text colors for light and dark modes. So when we create the documentation pages for our components, we don't need to have fixed background color and text color, then we should have basic pages for both dark mode and light mode for users to switch.
Besides, since there are no designs for 'light' mode pages, I think we can adjust some special colors on the documentation in light mode to make the whole page look more coordinated.
Here are my tests for Typography styles and types pages.
![image](https://user-images.githubusercontent.com/56696843/199045971-8b2ddee6-0758-452d-a38e-c1e856560ce1.png)
![image](https://user-images.githubusercontent.com/56696843/199046303-16f9b4bc-0531-4e69-a58f-3c890eeac7a6.png)
![image](https://user-images.githubusercontent.com/56696843/199046581-260966b8-94ca-40d3-af20-82da1dacf0e4.png)
![image](https://user-images.githubusercontent.com/56696843/199046685-17331858-a9b3-4f19-979c-558c7d8c535b.png)
