### PR TITLE
Fixed Storybook vertical divider height and splash screen height in doc view

### DIFF
--- a/docs/src/components/SplashScreen.stories.tsx
+++ b/docs/src/components/SplashScreen.stories.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@mui/material';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
 import SplashScreenStory from './SplashScreenStory';
@@ -14,7 +15,9 @@ export default {
 } as ComponentMeta<typeof SplashScreenStory>;
 
 const Template: ComponentStory<typeof SplashScreenStory> = (args) => (
-  <SplashScreenStory {...args} />
+  <Box sx={{ minHeight: '100vh' }}>
+    <SplashScreenStory {...args} />
+  </Box>
 );
 
 export const Screen = Template.bind({});

--- a/docs/src/mui/Divider.stories.tsx
+++ b/docs/src/mui/Divider.stories.tsx
@@ -44,7 +44,7 @@ export default {
 } as ComponentMeta<typeof MuiDivider>;
 
 const Template: ComponentStory<typeof MuiDivider> = (args) => {
-  return <MuiDivider {...args} />;
+  return <MuiDivider {...args} sx={{ height: '100vh' }} />;
 };
 
 export const Divider = Template.bind({});


### PR DESCRIPTION
The vertical Divider is now set to extend the length of the viewport. I also fixed the height of the Splash Screen when in doc mode.