### PR TITLE
Changeset config and GH CI setup

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,8 +3,8 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [],
-  "access": "restricted",
+  "linked": [["@ui-kit-2022/components", "@ui-kit-2022/theme", "@ui-kit-2022/docs"]],
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/.github/workflows/publish-components.yml
+++ b/.github/workflows/publish-components.yml
@@ -1,7 +1,7 @@
 name: Publish @ui-kit-2022/components to npmjs
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-theme.yml
+++ b/.github/workflows/publish-theme.yml
@@ -1,7 +1,7 @@
 name: Publish @ui-kit-2022/theme to npmjs
 on:
   release:
-    types: [created]
+    types: [published]
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Create .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create Release Pull Request or Publish
+        uses: changesets/action@v1
+        with:
+          publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,0 +1,36 @@
+# Adaptive UI-Kit 2022 Development
+
+## Setup
+
+1. Install [Node.js and NPM](https://nodejs.org/en/download/)
+2. Install Yarn2+ (https://yarnpkg.com/getting-started/install) and follow these steps:
+   - Run: `npm install -g yarn`
+   - Run: `yarn set version berry`
+3. Run the command `yarn`
+4. Run the command `yarn prepare`
+   - This will enable pre-commit check
+
+### Development Workflow
+
+This library is composed of several packages, most of which need to be built before your development and build tooling will work. The quickest way to build the package is to run the command: `yarn build`.
+
+While not always neccessary, you can remove all builds with `yarn clean`.
+
+See the `package.json` in the project root for a set of available quick commands that can be run with `yarn {command}`.
+
+To run a local command on a sub package, for instance if you only want to build a single package, you can run `yarn workspace {package-name} run {command}`. The package name is not the folder name, but the name in the packages own `package.json`. Examples of useful commands:
+
+- `yarn workspace @ui-kit-2022/components run build` to build the component package only.
+- `yarn workspace @ui-kit-2022/docs run preview` to run the storybook locally for development.
+- `yarn workspace @ui-kit-2022/theme run dev` to run a dev build of the theme package that auto rebuilds on change. The `@ui-kit-2022/components` package also supports a `dev` command.
+
+When developing in multiple packages at the same time, currently you'll need to run separate dev/preview commands for each package in order for each to auto rebuild so dependent packages to recongize changes in the package they depend upon.
+For instance, Storybook will no longer auto update when a file changes in the components package. You'll need to make sure the components package is autorebuilding along side the Storybook process to get a similar experience.
+
+## Releasing
+
+Releases are handled with [Changesets](https://github.com/changesets/changesets/).
+
+When adding a feature or fixing a bug, add to the changset before commiting and sending a PR if you think that change needs to be specified in the release changelog: `yarn changeset`
+
+As we merge in these changesets, a release PR will be created and updated with all the changesets that have been merged, handling all package version bumps and generating the changelog. Once that PR is approved and merged, a release will be created, and the new package versions will be published to NPM.

--- a/README.md
+++ b/README.md
@@ -50,32 +50,3 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   </React.StrictMode>
 );
 ```
-
-## Development
-
-### Setup
-
-1. Install [Node.js and NPM](https://nodejs.org/en/download/)
-2. Install Yarn2+ (https://yarnpkg.com/getting-started/install) and follow these steps:
-   - Run: `npm install -g yarn`
-   - Run: `yarn set version berry`
-3. Run the command `yarn`
-4. Run the command `yarn prepare`
-   - This will enable pre-commit check
-
-### Development Workflow
-
-This library is composed of several packages, most of which need to be built before your development and build tooling will work. The quickest way to build the package is to run the command: `yarn build`.
-
-While not always neccessary, you can remove all builds with `yarn clean`.
-
-See the `package.json` in the project root for a set of available quick commands that can be run with `yarn {command}`.
-
-To run a local command on a sub package, for instance if you only want to build a single package, you can run `yarn workspace {package-name} run {command}`. The package name is not the folder name, but the name in the packages own `package.json`. Examples of useful commands:
-
-- `yarn workspace @ui-kit-2022/components run build` to build the component package only.
-- `yarn workspace @ui-kit-2022/docs run preview` to run the storybook locally for development.
-- `yarn workspace @ui-kit-2022/theme run dev` to run a dev build of the theme package that auto rebuilds on change. The `@ui-kit-2022/components` package also supports a `dev` command.
-
-When developing in multiple packages at the same time, currently you'll need to run separate dev/preview commands for each package in order for each to auto rebuild so dependent packages to recongize changes in the package they depend upon.
-For instance, Storybook will no longer auto update when a file changes in the components package. You'll need to make sure the components package is autorebuilding along side the Storybook process to get a similar experience.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint:test": "eslint . --ext .jsx,.js,.ts,.tsx --ignore-path ./.gitignore",
     "prepare": "husky install",
     "clean": "rm -r ./dist; yarn workspaces foreach run clean",
-    "publish": "yarn workspaces foreach npm publish --tolerate-republish"
+    "release": "yarn build-lib && yarn changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.25.0",


### PR DESCRIPTION
Closes #74 

This includes release automation and changelog generation with Changesets, but it does not employ the branching strategy I shared. To automate that strategy with Changesets will require additional configuration, since Changesets will generate, not a single release, but a release for every package. This means that each package can have a different released version, which makes determining when to create a permanent release branch much more opaque.