### PR TITLE
Fixed issue with yarn.lock not updating in the changeset version workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
+          version: yarn version
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:test": "eslint . --ext .jsx,.js,.ts,.tsx --ignore-path ./.gitignore",
     "prepare": "husky install",
     "clean": "rm -r ./dist; yarn workspaces foreach run clean",
-    "release": "yarn build-lib && yarn changeset publish"
+    "release": "yarn build-lib && yarn changeset publish",
+    "version": "yarn changeset version && yarn"
   },
   "devDependencies": {
     "@changesets/cli": "^2.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4667,19 +4667,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ui-kit-2022/components@0.0.0, @ui-kit-2022/components@workspace:packages/ui-kit-components":
+"@ui-kit-2022/components@0.0.1, @ui-kit-2022/components@workspace:packages/ui-kit-components":
   version: 0.0.0-use.local
   resolution: "@ui-kit-2022/components@workspace:packages/ui-kit-components"
   dependencies:
     "@ui-kit-2022/svgr-template": ^1.0.0
-    "@ui-kit-2022/theme": 0.0.0
+    "@ui-kit-2022/theme": 0.0.1
     vite: ^3.1.0
   peerDependencies:
     "@emotion/react": ^11.10.4
     "@emotion/styled": ^11.10.4
     "@mui/icons-material": ^5.10.6
     "@mui/material": ^5.10.6
-    "@ui-kit-2022/theme": 0.0.0
+    "@ui-kit-2022/theme": 0.0.1
     react: ^18.2.0
     react-dom: ^18.2.0
   languageName: unknown
@@ -4700,9 +4700,9 @@ __metadata:
     "@storybook/builder-vite": ^0.2.2
     "@storybook/react": ^6.5.12
     "@storybook/testing-library": ^0.0.13
-    "@ui-kit-2022/components": 0.0.0
+    "@ui-kit-2022/components": 0.0.1
     "@ui-kit-2022/svgr-template": ^1.0.0
-    "@ui-kit-2022/theme": 0.0.0
+    "@ui-kit-2022/theme": 0.0.1
     babel-loader: ^8.2.5
     storybook-addon-pseudo-states: ^1.15.1
     storybook-dark-mode: ^1.1.2
@@ -4749,7 +4749,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ui-kit-2022/theme@0.0.0, @ui-kit-2022/theme@workspace:packages/ui-kit-theme":
+"@ui-kit-2022/theme@0.0.1, @ui-kit-2022/theme@workspace:packages/ui-kit-theme":
   version: 0.0.0-use.local
   resolution: "@ui-kit-2022/theme@workspace:packages/ui-kit-theme"
   dependencies:


### PR DESCRIPTION
Modified `release.yml` to ensure that `yarn.lock` is updated when generating a workflow PR. Otherwise all our Actions will break after merging a release PR. This commit also updates `yarn.lock` to be compatible with the new version bump I merged earlier. The workflow should now rerun and succeed this time.