### PR TITLE
Removed storyStoreV7 and babelModeV7

### DIFF
--- a/docs/.storybook/main.ts
+++ b/docs/.storybook/main.ts
@@ -17,10 +17,6 @@ export default {
   core: {
     builder: '@storybook/builder-vite',
   },
-  features: {
-    storyStoreV7: true,
-    babelModeV7: true,
-  },
   async viteFinal(config, { configType }) {
     config.base = process.env.BASE_PATH || config.base;
     config.plugins = [


### PR DESCRIPTION
Removing the V7 features seems to fix both of these issues. I added these before we moved to a monorepo to fix an issue with Storybooks manager having issues importing our other TS files into storybook's TS config files, but now that we import from the JS build files, it should be safe to remove them.

Fixes #128
Fixes #127