### PR TITLE
Added storybook-static to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ dist-ssr
 *.local
 node_modules/*
 scripts
+storybook-static


### PR DESCRIPTION
The linter is trying to lint js build artifacts in the storybook-static directory. This prevents it from doing so.