### PR TITLE
Icon Docs Responsive Design

### DIFF
--- a/docs/src/design-system/building-blocks/icons/color.tsx
+++ b/docs/src/design-system/building-blocks/icons/color.tsx
@@ -1,4 +1,4 @@
-import { Box, Grid, Palette, Typography, useTheme } from '@mui/material';
+import { Box, Grid, Palette, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { Icon } from '@ui-kit-2022/components';
 import * as React from 'react';
 
@@ -30,13 +30,14 @@ const IconsGroup: React.FC<{
     <Grid
       container
       rowGap={2}
-      sx={{ height: '100%', witdh: '100%', fontSize: '11px', fontWeight: '300' }}
+      sx={{ height: '100%', width: '100%', fontSize: '11px', fontWeight: '300' }}
     >
       <Grid item xs={12}>
         <Box
           sx={{
             display: 'flex',
             justifyContent: 'space-evenly',
+            flexWrap: 'wrap',
             alignItems: 'start',
             padding: '1rem 0rem',
             bgcolor: background === 'dark' ? palette.paper.black : palette.grey[50],
@@ -134,21 +135,35 @@ const IconsGroup: React.FC<{
 const Color: React.FC = () => {
   const { palette } = useTheme();
   return (
-    <Grid item xs={12}>
-      <Grid container columnGap={3}>
-        <Grid item xs={2}>
-          <SubTitle subTitle={COLOR.subTitle} />
-          <Typography variant="body2">{COLOR.paragraph1}</Typography>
-          <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
-            {COLOR.paragraph2}
-          </Typography>
-        </Grid>
-        <Grid item xs={2.5}>
+    <Grid container columns={{ xs: 2, md: 4 }} columnSpacing={5} rowGap={5}>
+      <Grid item xs={2} sm={1.5} md={1}>
+        <SubTitle subTitle={COLOR.subTitle} />
+        <Typography variant="body2">{COLOR.paragraph1}</Typography>
+        <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
+          {COLOR.paragraph2}
+        </Typography>
+      </Grid>
+      <Grid
+        item
+        container
+        xs={2}
+        md={1}
+        columns={2}
+        columnSpacing={2}
+        display="flex"
+        sx={{
+          flexDirection: useMediaQuery('(max-width: 400px') ? 'column' : null,
+          ' > div': {
+            maxWidth: useMediaQuery('(max-width: 400px') ? '100%' : null,
+          },
+        }}
+      >
+        <Grid item xs={1}>
           <IconsGroup palette={palette} background="dark">
             {COLOR.IconExampleExplanation1}
           </IconsGroup>
         </Grid>
-        <Grid item xs={2.5}>
+        <Grid item xs={1}>
           <IconsGroup palette={palette} background="light">
             {COLOR.IconExampleExplanation2}
           </IconsGroup>

--- a/docs/src/design-system/building-blocks/icons/icon-library.tsx
+++ b/docs/src/design-system/building-blocks/icons/icon-library.tsx
@@ -6,7 +6,7 @@ import { ICON_LIBRARY } from './icons.constants';
 
 const Text: React.FC = () => {
   return (
-    <Grid item xs={2}>
+    <Grid item>
       <SubTitle subTitle={ICON_LIBRARY.textTitle} />
       <Grid item xs={12}>
         <Typography variant="body2">{ICON_LIBRARY.text}</Typography>
@@ -45,8 +45,8 @@ const RenderIcons: React.FC<RenderIconsProps> = ({ column }) => {
 
 const ColumnOne: React.FC = () => {
   return (
-    <Grid item xs={1.5}>
-      <Grid container columnGap={1}>
+    <Grid item>
+      <Grid container columnGap={{ xs: 0, sm: 2 }}>
         <RenderIcons column={ICON_LIBRARY.icons.columnOne} />
       </Grid>
     </Grid>
@@ -55,8 +55,8 @@ const ColumnOne: React.FC = () => {
 
 const ColumnTwo: React.FC = () => {
   return (
-    <Grid item xs={1.5}>
-      <Grid container columnGap={1}>
+    <Grid item>
+      <Grid container columnGap={{ xs: 0, sm: 2 }}>
         <RenderIcons column={ICON_LIBRARY.icons.columnTwo} />
       </Grid>
     </Grid>
@@ -65,8 +65,8 @@ const ColumnTwo: React.FC = () => {
 
 const ColumnThree: React.FC = () => {
   return (
-    <Grid item xs={1.5}>
-      <Grid container columnGap={1}>
+    <Grid item>
+      <Grid container columnGap={{ xs: 0, sm: 2 }}>
         <RenderIcons column={ICON_LIBRARY.icons.columnThree} />
       </Grid>
     </Grid>
@@ -83,28 +83,31 @@ const RenderColumnFourIcons: React.FC<RenderColumnFourIconsProps> = ({
   icons,
 }) => {
   return (
-    <>
-      {icons.map((icon, index) => (
-        <Grid
-          key={index + icon.length}
-          item
-          xs={1.5}
-          sx={{ display: 'flex', alignItems: 'center' }}
-        >
-          <SvgIcon component={icon} sx={{ width: '16px', height: '16px' }} />
-        </Grid>
-      ))}
-      <Grid item xs={3} sx={{ display: 'flex', alignItems: 'start' }}>
+    <Grid container columns={10} columnSpacing={{ xs: 0, sm: 5, md: 0 }}>
+      <Grid item container xs={4} sm={6} columnGap={{ xs: 1, sm: 4, md: 1 }}>
+        {icons.map((icon, index) => (
+          <Grid
+            key={index + icon.length}
+            item
+            xs={1}
+            sm={1.5}
+            sx={{ display: 'flex', alignItems: 'center' }}
+          >
+            <SvgIcon component={icon} sx={{ width: '16px', height: '16px' }} />
+          </Grid>
+        ))}
+      </Grid>
+      <Grid item xs={2} sx={{ display: 'flex', alignItems: 'start' }}>
         <Typography variant="body2">{label}</Typography>
       </Grid>
-    </>
+    </Grid>
   );
 };
 
 const ColumnFour: React.FC = () => {
   return (
-    <Grid item xs={1.5}>
-      <Grid container columnGap={1}>
+    <Grid item>
+      <Grid container columnGap={{ xs: 0, sm: 4 }}>
         <RenderColumnFourIcons
           icons={ICON_LIBRARY.icons.columnFour[0].icons}
           label={ICON_LIBRARY.icons.columnFour[0].label}
@@ -120,13 +123,31 @@ const ColumnFour: React.FC = () => {
 
 const IconLibrary: React.FC = () => {
   return (
-    <Grid item xs={12}>
-      <Grid container columnGap={3}>
+    <Grid container columns={{ xs: 2, sm: 4, md: 4 }} columnSpacing={1} rowGap={5}>
+      <Grid item xs={2} sm={3} md={1}>
         <Text />
-        <ColumnOne />
-        <ColumnTwo />
-        <ColumnThree />
-        <ColumnFour />
+      </Grid>
+      <Grid
+        item
+        container
+        columns={{ xs: 4, sm: 5 }}
+        xs={4}
+        sm={3}
+        gap={{ xs: 0, sm: 4, md: 4 }}
+        rowGap={{ xs: 4, sm: 0, md: 0 }}
+      >
+        <Grid item xs={2} sm={1}>
+          <ColumnOne />
+        </Grid>
+        <Grid item xs={2} sm={1}>
+          <ColumnTwo />
+        </Grid>
+        <Grid item xs={2} sm={1}>
+          <ColumnThree />
+        </Grid>
+        <Grid item xs={2} sm={1}>
+          <ColumnFour />
+        </Grid>
       </Grid>
     </Grid>
   );

--- a/docs/src/design-system/building-blocks/icons/icons.constants.ts
+++ b/docs/src/design-system/building-blocks/icons/icons.constants.ts
@@ -15,7 +15,7 @@ const PURPOSE = {
 const SIZING = {
   paragraph1: 'Use icons in approved sizes with enough space around them.',
   paragraph2:
-    'They are sized to take up the central 75% of a square, transparent frame whose pixel dimensions are one of our approved sizing increments of S, M, L or XL. =',
+    'They are sized to take up the central 75% of a square, transparent frame whose pixel dimensions are one of our approved sizing increments of S, M, L or XL.',
   paragraph3: 'The use of S and XL icons will be rare.',
   sizes: ['S', 'M', 'L', 'XL'],
   errorSizes: ['Too small!', 'Too big!'],

--- a/docs/src/design-system/building-blocks/icons/purpose.tsx
+++ b/docs/src/design-system/building-blocks/icons/purpose.tsx
@@ -5,7 +5,7 @@ import { SubTitle } from '../common';
 import { PURPOSE } from './icons.constants';
 const Purpose: React.FC = () => {
   return (
-    <Grid container>
+    <Grid item container xs={12} sm={9} md={12}>
       <SubTitle subTitle={PURPOSE.title} />
       <Grid item xs={12}>
         <Typography variant="body2">{PURPOSE.paragraph1}</Typography>

--- a/docs/src/design-system/building-blocks/icons/sizing.tsx
+++ b/docs/src/design-system/building-blocks/icons/sizing.tsx
@@ -111,17 +111,17 @@ const Sizing = () => {
   const { palette } = useTheme();
 
   return (
-    <Grid item xs={12}>
-      <Grid container columnGap={3}>
-        <Grid item xs={2}>
-          <SubTitle subTitle="Sizing" />
-          <Typography variant="body2">{SIZING.paragraph1}</Typography>
-          <Typography variant="body2">{SIZING.paragraph2}</Typography>
-          <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
-            {SIZING.paragraph3}
-          </Typography>
-        </Grid>
-        <Grid item xs={1.5} sx={ICONS_GROUP_LAYOUT_STYLE}>
+    <Grid container columns={{ xs: 1, sm: 4 }} columnSpacing={6} rowGap={2}>
+      <Grid item xs={1} sm={2} md={1}>
+        <SubTitle subTitle="Sizing" />
+        <Typography variant="body2">{SIZING.paragraph1}</Typography>
+        <Typography variant="body2">{SIZING.paragraph2}</Typography>
+        <Typography variant="body2" sx={{ fontStyle: 'italic' }}>
+          {SIZING.paragraph3}
+        </Typography>
+      </Grid>
+      <Grid item container columns={3} xs={3} sm={1.25} columnGap={{ xs: 4, sm: 5 }}>
+        <Grid item xs={1} sx={ICONS_GROUP_LAYOUT_STYLE}>
           <Grid container sx={CONTAINER_SIZE}>
             {SIZING.sizes.map((value) => (
               <IconSubtitleComponent key={value} palette={palette}>
@@ -130,7 +130,7 @@ const Sizing = () => {
             ))}
           </Grid>
         </Grid>
-        <Grid item xs={1.3} sx={ICONS_GROUP_LAYOUT_STYLE}>
+        <Grid item xs={1} sx={ICONS_GROUP_LAYOUT_STYLE}>
           <Grid container sx={CONTAINER_SIZE}>
             {SIZING.errorSizes.map((value) => (
               <IconSubtitleComponent key={value} palette={palette}>

--- a/docs/src/design-system/building-blocks/icons/with-text.tsx
+++ b/docs/src/design-system/building-blocks/icons/with-text.tsx
@@ -13,9 +13,10 @@ import * as React from 'react';
 
 import { SubTitle } from '../common';
 import { WITH_TEXT } from './icons.constants';
+
 const Text: React.FC = () => {
   return (
-    <Grid item xs={2}>
+    <Grid item xs={4}>
       <SubTitle subTitle={WITH_TEXT.subTitle} />
       <Grid item xs={12}>
         <Typography variant="body2">{WITH_TEXT.paragraph1}</Typography>
@@ -241,12 +242,17 @@ const DontIconWithActions: React.FC<{ palette: Palette }> = ({ palette }) => {
 
 const WithText: React.FC = () => {
   const { palette } = useTheme();
+
   return (
-    <Grid item xs={12}>
-      <Grid container columnGap={3}>
+    <Grid container columns={{ xs: 1, sm: 2, md: 4 }} columnSpacing={6} rowGap={5}>
+      <Grid item xs={1} sm={1.5} md={1}>
         <Text />
+      </Grid>
+      <Grid item xs={2} display="flex" gap={6}>
         <DoIconWithLabel palette={palette} />
         <DontIconWithLabel palette={palette} />
+      </Grid>
+      <Grid item xs={2} md={1} display="flex" gap={6}>
         <DoIconWithActions palette={palette} />
         <DontIconWithActions palette={palette} />
       </Grid>

--- a/docs/src/design-system/icons/icons.tsx
+++ b/docs/src/design-system/icons/icons.tsx
@@ -1,5 +1,4 @@
 import { Grid, useTheme } from '@mui/material';
-import { BrandIcon } from '@ui-kit-2022/components';
 import * as React from 'react';
 
 import { TopBar } from '../building-blocks/common';
@@ -8,9 +7,9 @@ const Icons: React.FC = () => {
   const { palette } = useTheme();
 
   return (
-    <Grid container sx={{ width: '1005px' }}>
+    <Grid container sx={{ maxWidth: '1100px' }}>
       <Grid item xs={12}>
-        <TopBar icon={BrandIcon.LogoSmall} title={'Icons'} />
+        <TopBar title={'Icons'} />
       </Grid>
       <Grid
         container
@@ -20,7 +19,7 @@ const Icons: React.FC = () => {
           color: palette.text.primary,
           padding: '1rem',
         }}
-        rowGap={6}
+        rowGap={7}
       >
         <Purpose />
         <Sizing />


### PR DESCRIPTION
Closes #162 

Added a responsive design for the icon docs page.  Smallest screen size it supports is 320px.