### PR TITLE
Fixed issue 114: Pseudo states don't render when toggling theme

### DIFF
--- a/docs/src/Home.stories.mdx
+++ b/docs/src/Home.stories.mdx
@@ -27,4 +27,4 @@ View their code in the `.stories.tsx` files to learn how they work.
 
 
 ## Usage Issues
- * Toggling the theme (light or dark) will cause component psuedo states to disapear. Reloading the window will reset them. See: https://github.com/AdaptiveConsulting/ui-kit-2022/issues/114
+ * Pseudo states will not render correctly when switching between stories in Docs mode. Toggling between Docs/Canvas mode will reset the pseudo states.


### PR DESCRIPTION
Fixes #114

There is still an issue of incorrect pseudo state rendering when switching between stories in docs mode, but the original issue is solved. I'll create another issue for this.