### PR TITLE
Fixed chromatic deploy heap memory out of bounds error

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,3 +29,6 @@ jobs:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: docs
+        env:
+          NODE_OPTIONS: "--max_old_space_size=4096"
+


### PR DESCRIPTION
Same fix as the one in the Storybook workflow but for the Chromatic workflow.