### PR TITLE
Add Playground Page

### DIFF
--- a/docs/.storybook/preview.tsx
+++ b/docs/.storybook/preview.tsx
@@ -1,5 +1,5 @@
 import '@ui-kit-2022/theme/dist/style.css';
-
+import React from 'react';
 import { themes } from '@storybook/theming';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';

--- a/docs/src/playground/ExamplePage.tsx
+++ b/docs/src/playground/ExamplePage.tsx
@@ -1,0 +1,11 @@
+import { Grid } from '@mui/material';
+
+export default function ExamplePage() {
+  return (
+    <Grid
+      container
+      columns={{ xs: 2, sm: 4, md: 8, lg: 12 }}
+      sx={{ height: '100%' }}
+    ></Grid>
+  );
+}

--- a/docs/src/playground/StocksPage.stories.tsx
+++ b/docs/src/playground/StocksPage.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentMeta } from '@storybook/react';
+
+import ExamplePage from './ExamplePage';
+
+export default {
+  title: 'Playground',
+  component: ExamplePage,
+  decorators: [
+    (Story) => (
+      //Styling to override global decorator's padding
+      <div style={{ position: 'absolute', top: 0, left: 0, bottom: 0, width: '100%' }}>
+        <Story />
+      </div>
+    ),
+  ],
+} as ComponentMeta<typeof ExamplePage>;
+
+const Template = () => <ExamplePage />;
+
+export const StocksPage = Template.bind({});


### PR DESCRIPTION
I removed the navbar I mentioned in standup since I need to clarify with Nate on how its branding should present on smaller screens.  

The playground page doesn't have it's own `"Category"` for now.  I thought it'd be better to have a simple grouping since there's not much content.  It displays first before the categories.
![image](https://user-images.githubusercontent.com/106989342/203131076-a1b98fa5-2849-450c-bac6-589cfd9f9a3b.png)
