### PR TITLE
Create footer index ticker doc page

### DIFF
--- a/docs/src/design-system/building-blocks/table/IndexTickerMobile.tsx
+++ b/docs/src/design-system/building-blocks/table/IndexTickerMobile.tsx
@@ -1,0 +1,99 @@
+import {
+  Box,
+  Divider,
+  Palette,
+  SimplePaletteColorOptions,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { Icon } from '@ui-kit-2022/components';
+import * as React from 'react';
+
+interface SellBugProps {
+  sell: SimplePaletteColorOptions;
+  buy: SimplePaletteColorOptions;
+}
+
+export interface Props {
+  name: string;
+  latestPrice: number;
+  changedPrice: number;
+  percentage: number;
+  includeDivider?: boolean;
+}
+const getRoundedToTwo = (num: number) => {
+  return Number(num).toFixed(2).padEnd(2, '0');
+};
+const color = (palette: Palette & SellBugProps, changedPrice: number) => {
+  if (changedPrice === 0) {
+    return {};
+  } else if (changedPrice < 0) {
+    return { color: palette.sell.main };
+  } else {
+    return { color: palette.success.main };
+  }
+};
+
+const IndexTickerMobile: React.FC<Props> = ({
+  name = 'Name',
+  latestPrice = 0,
+  changedPrice = 0,
+  percentage = 0,
+  includeDivider = true,
+}) => {
+  const { palette } = useTheme();
+  return (
+    <Box height={'4rem'} display="flex">
+      {includeDivider && <Divider orientation="vertical" flexItem />}
+      <Box mx={4} display="flex" flexDirection={'column'} justifyContent={'space-evenly'}>
+        <Box display={'flex'} alignItems="center" justifyContent={'space-between'}>
+          <Typography variant="subheader3">{name}</Typography>
+          <Typography variant="body2">${getRoundedToTwo(latestPrice)}</Typography>
+        </Box>
+        <Box display={'flex'} alignItems="center">
+          <Box width={'1rem'} height={'1rem'} textAlign="center">
+            {changedPrice !== 0 &&
+              (changedPrice < 0 ? (
+                <Icon.ArrowDown
+                  sx={{
+                    pb: '3px',
+                    color: (palette as Palette & SellBugProps).sell.main,
+                  }}
+                />
+              ) : (
+                <Icon.ArrowUp
+                  sx={{
+                    pb: '3px',
+                    color: (palette as Palette & SellBugProps).success.main,
+                  }}
+                />
+              ))}
+          </Box>
+          <Typography
+            variant="body2"
+            sx={color(palette as Palette & SellBugProps, changedPrice)}
+            ml={changedPrice === 0 ? 3 : 1}
+          >
+            {changedPrice >= 0
+              ? `+${getRoundedToTwo(changedPrice)}`
+              : getRoundedToTwo(changedPrice)}
+          </Typography>
+          <Box mx={1} sx={color(palette as Palette & SellBugProps, changedPrice)}>
+            |
+          </Box>
+          <Typography
+            variant="body2"
+            sx={color(palette as Palette & SellBugProps, changedPrice)}
+          >
+            {percentage >= 0
+              ? `+${getRoundedToTwo(percentage)}`
+              : getRoundedToTwo(percentage)}
+            %
+          </Typography>
+        </Box>
+      </Box>
+      {includeDivider && <Divider orientation="vertical" flexItem />}
+    </Box>
+  );
+};
+export default IndexTickerMobile;

--- a/docs/src/design-system/building-blocks/table/TickerBarMobile.tsx
+++ b/docs/src/design-system/building-blocks/table/TickerBarMobile.tsx
@@ -1,10 +1,9 @@
-import { Box, useMediaQuery, useTheme } from '@mui/material';
-import { IndexTickers } from '@ui-kit-2022/components';
+import { Box, useTheme } from '@mui/material';
 
-const TickerBar: React.FC = () => {
+import IndexTickerMobile from './IndexTickerMobile';
+
+const TickerBarMobile: React.FC = () => {
   const { palette } = useTheme();
-  const matches = useMediaQuery('(min-width:830px)');
-
   return (
     <Box
       pt={2}
@@ -12,22 +11,22 @@ const TickerBar: React.FC = () => {
       width={'100%'}
       borderColor={palette.divider}
       display={'flex'}
-      justifyContent={matches ? 'flex-start' : 'center'}
+      justifyContent={'center'}
     >
-      <IndexTickers
+      <IndexTickerMobile
         includeDivider={false}
         name={'SPA'}
         latestPrice={333.98}
         changedPrice={-2.97}
         percentage={-0.9}
       />
-      <IndexTickers
+      <IndexTickerMobile
         name={'DIA'}
         latestPrice={290.12}
         changedPrice={1.67}
         percentage={0.64}
       />
-      <IndexTickers
+      <IndexTickerMobile
         includeDivider={false}
         name={'IWM'}
         latestPrice={167.45}
@@ -38,4 +37,4 @@ const TickerBar: React.FC = () => {
   );
 };
 
-export default TickerBar;
+export default TickerBarMobile;

--- a/docs/src/design-system/tables/FooterIndexTicker.stories.tsx
+++ b/docs/src/design-system/tables/FooterIndexTicker.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import FooterIndexTicker from './FooterIndexTicker';
+
+export default {
+  title: 'Design System / Tables',
+  component: FooterIndexTicker,
+} as ComponentMeta<typeof FooterIndexTicker>;
+
+const Template: ComponentStory<typeof FooterIndexTicker> = () => <FooterIndexTicker />;
+
+export const FooterIndexTickerStory = Template.bind({});
+FooterIndexTickerStory.storyName = 'Footer Index Ticker';

--- a/docs/src/design-system/tables/FooterIndexTicker.tsx
+++ b/docs/src/design-system/tables/FooterIndexTicker.tsx
@@ -1,0 +1,120 @@
+import { Box, Container, Grid, ThemeProvider, useTheme } from '@mui/material';
+import { Typography } from '@ui-kit-2022/components';
+import { dark, light } from '@ui-kit-2022/theme';
+
+import TickerBar from '../../components/TickerBar';
+import { TopBar } from '../building-blocks/common';
+import TickerBarMobile from '../building-blocks/table/TickerBarMobile';
+
+const FooterIndexTicker: React.FC = () => {
+  const theme = useTheme();
+  const customizedTheme = theme === light ? dark : light;
+  return (
+    <>
+      <TopBar title={'Special Table: Footer index ticker'} />
+      <Container disableGutters={true}>
+        <Box p={5}>
+          <Box>
+            <Typography variant="h4" mb={3}>
+              Purpose
+            </Typography>
+            <Typography variant="body2">
+              This is a guide to the special case footer on the bottom of the page, which
+              is composed of modified table cells.
+            </Typography>
+          </Box>
+          <Box mt={7}>
+            <Grid container columnSpacing={5} alignItems="center">
+              <Grid item xs={2}>
+                <Box>
+                  <Typography variant="h4" mb={3}>
+                    Cells
+                  </Typography>
+                  <Typography variant="body2" mb={3}>
+                    The footer has three cells, each with:
+                  </Typography>
+
+                  <Typography variant="body2">
+                    Ticker
+                    <br />
+                    Current price
+                    <br />
+                    Direction (indicated by color and an arrow)
+                    <br />
+                    Price movement and percentage movement amounts
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={10}>
+                <Box px={5}>
+                  <TickerBar />
+                </Box>
+              </Grid>
+            </Grid>
+          </Box>
+          <Box mt={7}>
+            <Grid container columnSpacing={5} alignItems="flex-start">
+              <Grid item xs={2}>
+                <Box>
+                  <Typography variant="h4" mb={3}>
+                    Alignment
+                  </Typography>
+                  <Typography variant="body2" mb={3}>
+                    When in a viewport wide enough to show it this way, all data should be
+                    in a left-to-right inline layout. The three tickers should align to
+                    the left of the bar, leaving the space to the right open.
+                  </Typography>
+                  <Typography variant="body2">
+                    Smaller views may require a stacked configuration of the cells. Those
+                    three cells should be centered within the bounding container.
+                  </Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={10}>
+                <Box>
+                  <ThemeProvider theme={customizedTheme}>
+                    <Box
+                      bgcolor={customizedTheme.palette.background.paper}
+                      color={customizedTheme.palette.text.primary}
+                      p={2}
+                      mb={2}
+                    >
+                      <TickerBar />
+                    </Box>
+                  </ThemeProvider>
+                  <Box display={'flex'}>
+                    <ThemeProvider theme={customizedTheme}>
+                      <Box
+                        bgcolor={customizedTheme.palette.background.paper}
+                        color={customizedTheme.palette.text.primary}
+                        display="flex"
+                        alignItems={'flex-end'}
+                        minWidth={'388px'}
+                        height={'812px'}
+                        mr={4}
+                        pb={2}
+                      >
+                        <TickerBarMobile />
+                      </Box>
+                    </ThemeProvider>
+                    <Box
+                      minWidth={'563px'}
+                      height={'812px'}
+                      border={`1px solid ${theme.palette.divider}`}
+                      display="flex"
+                      alignItems={'flex-end'}
+                      pb={2}
+                    >
+                      <TickerBarMobile />
+                    </Box>
+                  </Box>
+                </Box>
+              </Grid>
+            </Grid>
+          </Box>
+        </Box>
+      </Container>
+    </>
+  );
+};
+export default FooterIndexTicker;

--- a/docs/src/design-system/tables/TableUsagePage.stories.tsx
+++ b/docs/src/design-system/tables/TableUsagePage.stories.tsx
@@ -3,11 +3,11 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import TableUsagePage from './TableUsagePage';
 
 export default {
-  title: 'Design System',
+  title: 'Design System / Tables',
   component: TableUsagePage,
 } as ComponentMeta<typeof TableUsagePage>;
 
 const Template: ComponentStory<typeof TableUsagePage> = () => <TableUsagePage />;
 
 export const TableUsage = Template.bind({});
-TableUsage.storyName = 'Tables';
+TableUsage.storyName = 'Table Usage';


### PR DESCRIPTION
I was not able to display the mobile style of` IndexTickers` componenet directly on this doc page(since this component was made responsive based on the screen size), so I had some extra code of `IndexTickerMobile` and `TickerBarMobile` in the `building block ` to just be used in this page. (Example doc page: [https://www.figma.com/file/vVwPje7l17NXssVR86wfYn/Reactive-Analytics---Design-System?node-id=3030%3A43447&t=rBza3PJrYEqW5BgJ-0](url))

![image](https://user-images.githubusercontent.com/56696843/203147968-ca69c753-729b-4fe4-89f3-e5bd2c030740.png)
![image](https://user-images.githubusercontent.com/56696843/203148171-0289eb99-7311-4dfe-b889-6d0041dc1c80.png)
