### PR TITLE
Graph doc overlap

### DIFF
--- a/docs/src/design-system/charts/mobile-responsiveness.tsx
+++ b/docs/src/design-system/charts/mobile-responsiveness.tsx
@@ -82,28 +82,32 @@ const MobileResponsiveness: React.FC = () => {
               />
             </Grid>
           </Grid>
-{matchSm &&          <Grid item xs={12} container>
-            <Grid item xs={10} sm={8} lg={6}>
-              <Graph
-                labels={labels}
-                data={data}
-                yLabelStep={yLabelStepM}
-                xLabelStep={60}
-                previousData={previousData}
-              />
+          {matchSm && (
+            <Grid item xs={12} container>
+              <Grid item xs={10} sm={8} lg={6}>
+                <Graph
+                  labels={labels}
+                  data={data}
+                  yLabelStep={yLabelStepM}
+                  xLabelStep={60}
+                  previousData={previousData}
+                />
+              </Grid>
             </Grid>
-          </Grid>}
-          {matchLg && <Grid item xs={12} container>
-            <Grid item xs={12} sm={10} lg={8}>
-              <Graph
-                labels={labels}
-                data={data}
-                yLabelStep={yLabelStepL}
-                xLabelStep={30}
-                previousData={previousData}
-              />
+          )}
+          {matchLg && (
+            <Grid item xs={12} container>
+              <Grid item xs={12} sm={10} lg={8}>
+                <Graph
+                  labels={labels}
+                  data={data}
+                  yLabelStep={yLabelStepL}
+                  xLabelStep={30}
+                  previousData={previousData}
+                />
+              </Grid>
             </Grid>
-          </Grid>}
+          )}
         </Grid>
       </Grid>
     </Grid>

--- a/docs/src/design-system/charts/mobile-responsiveness.tsx
+++ b/docs/src/design-system/charts/mobile-responsiveness.tsx
@@ -5,7 +5,8 @@ import * as React from 'react';
 import generateData from './generate-data';
 const MobileResponsiveness: React.FC = () => {
   const theme = useTheme();
-  const match = useMediaQuery(theme.breakpoints.up('lg'));
+  const matchLg = useMediaQuery(theme.breakpoints.up('lg'));
+  const matchSm = useMediaQuery(theme.breakpoints.up('sm'));
 
   const { data, labels, previousData } = generateData();
   const yLabelStep = Math.ceil((Math.max(...data[0]) - Math.min(...data[0])) / 2);
@@ -66,7 +67,7 @@ const MobileResponsiveness: React.FC = () => {
           item
           lg={10}
           xs={12}
-          sx={{ p: match ? '0rem 2rem' : '0rem' }}
+          sx={{ p: matchLg ? '0rem 2rem' : '0rem' }}
           container
           spacing={6}
         >
@@ -81,7 +82,7 @@ const MobileResponsiveness: React.FC = () => {
               />
             </Grid>
           </Grid>
-          <Grid item xs={12} container>
+{matchSm &&          <Grid item xs={12} container>
             <Grid item xs={10} sm={8} lg={6}>
               <Graph
                 labels={labels}
@@ -91,8 +92,8 @@ const MobileResponsiveness: React.FC = () => {
                 previousData={previousData}
               />
             </Grid>
-          </Grid>
-          <Grid item xs={12} container>
+          </Grid>}
+          {matchLg && <Grid item xs={12} container>
             <Grid item xs={12} sm={10} lg={8}>
               <Graph
                 labels={labels}
@@ -102,7 +103,7 @@ const MobileResponsiveness: React.FC = () => {
                 previousData={previousData}
               />
             </Grid>
-          </Grid>
+          </Grid>}
         </Grid>
       </Grid>
     </Grid>


### PR DESCRIPTION
To solve the labels overlap issue on the graph doc, we show only certain charts with sizes accordingly to the screen. 
like for mobile:
![Screen Shot 2022-11-28 at 8 10 41 AM](https://user-images.githubusercontent.com/106985561/204286441-1d25bc56-0603-4212-ae61-369248e875fe.png)
for tablet:
![Screen Shot 2022-11-28 at 8 10 22 AM](https://user-images.githubusercontent.com/106985561/204286480-6849fc57-f994-4ffd-9aab-f0339fce95a5.png)
And for normal screen:

![Screen Shot 2022-11-28 at 8 09 50 AM](https://user-images.githubusercontent.com/106985561/204286526-2987e35f-3032-4d03-96ca-9470503d80f7.png)
