### PR TITLE
Add responsive view for index ticker doc page

### DIFF
--- a/docs/src/design-system/tables/FooterIndexTicker.tsx
+++ b/docs/src/design-system/tables/FooterIndexTicker.tsx
@@ -100,7 +100,7 @@ const FooterIndexTicker: React.FC = () => {
                           color={customizedTheme.palette.text.primary}
                           display="flex"
                           alignItems={'flex-end'}
-                          minWidth={'388px'}
+                          minWidth={'385px'}
                           height={'812px'}
                           mr={4}
                           pb={2}
@@ -109,7 +109,7 @@ const FooterIndexTicker: React.FC = () => {
                         </Box>
                       </ThemeProvider>
                       <Box
-                        minWidth={'563px'}
+                        minWidth={'500px'}
                         height={'812px'}
                         border={`1px solid ${theme.palette.divider}`}
                         display="flex"

--- a/docs/src/design-system/tables/FooterIndexTicker.tsx
+++ b/docs/src/design-system/tables/FooterIndexTicker.tsx
@@ -1,4 +1,11 @@
-import { Box, Container, Grid, ThemeProvider, useTheme } from '@mui/material';
+import {
+  Box,
+  Container,
+  Grid,
+  ThemeProvider,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { Typography } from '@ui-kit-2022/components';
 import { dark, light } from '@ui-kit-2022/theme';
 
@@ -9,6 +16,7 @@ import TickerBarMobile from '../building-blocks/table/TickerBarMobile';
 const FooterIndexTicker: React.FC = () => {
   const theme = useTheme();
   const customizedTheme = theme === light ? dark : light;
+  const matchMd = useMediaQuery(theme.breakpoints.up('md'));
   return (
     <>
       <TopBar title={'Special Table: Footer index ticker'} />
@@ -25,7 +33,7 @@ const FooterIndexTicker: React.FC = () => {
           </Box>
           <Box mt={7}>
             <Grid container columnSpacing={5} alignItems="center">
-              <Grid item xs={2}>
+              <Grid item md={2} xs={12}>
                 <Box>
                   <Typography variant="h4" mb={3}>
                     Cells
@@ -45,8 +53,8 @@ const FooterIndexTicker: React.FC = () => {
                   </Typography>
                 </Box>
               </Grid>
-              <Grid item xs={10}>
-                <Box px={5}>
+              <Grid item md={10} xs={12}>
+                <Box px={matchMd ? 5 : 1} mt={matchMd ? {} : 4}>
                   <TickerBar />
                 </Box>
               </Grid>
@@ -54,7 +62,7 @@ const FooterIndexTicker: React.FC = () => {
           </Box>
           <Box mt={7}>
             <Grid container columnSpacing={5} alignItems="flex-start">
-              <Grid item xs={2}>
+              <Grid item md={2} xs={12}>
                 <Box>
                   <Typography variant="h4" mb={3}>
                     Alignment
@@ -70,44 +78,48 @@ const FooterIndexTicker: React.FC = () => {
                   </Typography>
                 </Box>
               </Grid>
-              <Grid item xs={10}>
+              <Grid item md={10} xs={12}>
                 <Box>
                   <ThemeProvider theme={customizedTheme}>
                     <Box
                       bgcolor={customizedTheme.palette.background.paper}
                       color={customizedTheme.palette.text.primary}
-                      p={2}
+                      py={2}
+                      px={matchMd ? 5 : 1}
                       mb={2}
+                      mt={matchMd ? {} : 4}
                     >
                       <TickerBar />
                     </Box>
                   </ThemeProvider>
-                  <Box display={'flex'}>
-                    <ThemeProvider theme={customizedTheme}>
+                  {matchMd && (
+                    <Box display={'flex'}>
+                      <ThemeProvider theme={customizedTheme}>
+                        <Box
+                          bgcolor={customizedTheme.palette.background.paper}
+                          color={customizedTheme.palette.text.primary}
+                          display="flex"
+                          alignItems={'flex-end'}
+                          minWidth={'388px'}
+                          height={'812px'}
+                          mr={4}
+                          pb={2}
+                        >
+                          <TickerBarMobile />
+                        </Box>
+                      </ThemeProvider>
                       <Box
-                        bgcolor={customizedTheme.palette.background.paper}
-                        color={customizedTheme.palette.text.primary}
+                        minWidth={'563px'}
+                        height={'812px'}
+                        border={`1px solid ${theme.palette.divider}`}
                         display="flex"
                         alignItems={'flex-end'}
-                        minWidth={'388px'}
-                        height={'812px'}
-                        mr={4}
                         pb={2}
                       >
                         <TickerBarMobile />
                       </Box>
-                    </ThemeProvider>
-                    <Box
-                      minWidth={'563px'}
-                      height={'812px'}
-                      border={`1px solid ${theme.palette.divider}`}
-                      display="flex"
-                      alignItems={'flex-end'}
-                      pb={2}
-                    >
-                      <TickerBarMobile />
                     </Box>
-                  </Box>
+                  )}
                 </Box>
               </Grid>
             </Grid>

--- a/packages/ui-kit-components/src/components/IndexTickers/IndexTickers.tsx
+++ b/packages/ui-kit-components/src/components/IndexTickers/IndexTickers.tsx
@@ -43,10 +43,10 @@ const IndexTickers: React.FC<Props> = ({
   includeDivider = true,
 }) => {
   const theme = useTheme();
-  const IsBiggerThanSM = useMediaQuery(theme.breakpoints.up('sm'));
-  const IsSmallerThanXS = useMediaQuery('(max-width: 375px)');
-  const Matches = useMediaQuery('(max-width: 420px)');
-  if (IsBiggerThanSM) {
+  const IsBiggerScreen = useMediaQuery('(min-width: 700px)');
+  const IsSmallestScreen = useMediaQuery('(max-width: 410px)');
+  const Matches = useMediaQuery('(max-width: 440px)');
+  if (IsBiggerScreen) {
     return (
       <Box height={'2rem'} display="flex" alignItems={'center'}>
         {includeDivider && <Divider orientation="vertical" flexItem />}
@@ -100,7 +100,7 @@ const IndexTickers: React.FC<Props> = ({
     );
   } else {
     return (
-      <Box height={IsSmallerThanXS ? '3rem' : '4rem'} display="flex">
+      <Box height={IsSmallestScreen ? '3rem' : '4rem'} display="flex">
         {includeDivider && <Divider orientation="vertical" flexItem />}
         <Box
           mx={Matches ? 2 : 4}
@@ -109,10 +109,10 @@ const IndexTickers: React.FC<Props> = ({
           justifyContent={'space-evenly'}
         >
           <Box display={'flex'} alignItems="center" justifyContent={'space-between'}>
-            <Typography variant="subheader3" fontSize={IsSmallerThanXS ? '8px' : '12px'}>
+            <Typography variant="subheader3" fontSize={IsSmallestScreen ? '8px' : '12px'}>
               {name}
             </Typography>
-            <Typography variant="body2" fontSize={IsSmallerThanXS ? '8px' : '12px'}>
+            <Typography variant="body2" fontSize={IsSmallestScreen ? '8px' : '12px'}>
               ${getRoundedToTwo(latestPrice)}
             </Typography>
           </Box>
@@ -137,7 +137,7 @@ const IndexTickers: React.FC<Props> = ({
             </Box>
             <Typography
               variant="body2"
-              fontSize={IsSmallerThanXS ? '8px' : '12px'}
+              fontSize={IsSmallestScreen ? '8px' : '12px'}
               sx={color(theme.palette as Palette & SellBugProps, changedPrice)}
               ml={changedPrice === 0 ? 3 : 1}
             >
@@ -150,7 +150,7 @@ const IndexTickers: React.FC<Props> = ({
             </Box>
             <Typography
               variant="body2"
-              fontSize={IsSmallerThanXS ? '8px' : '12px'}
+              fontSize={IsSmallestScreen ? '8px' : '12px'}
               sx={color(theme.palette as Palette & SellBugProps, changedPrice)}
             >
               {percentage >= 0


### PR DESCRIPTION
As discussed with Nate, when we reach the breakpoints `md` (the screen size is smaller than 900px), these two examples will be removed from the doc page.
![image](https://user-images.githubusercontent.com/56696843/204362879-ab17b970-4f5b-42cd-89be-f4217d91ff82.png)
