### PR TITLE
Create playground stock price footer

### DIFF
--- a/docs/src/playground/ExamplePage.tsx
+++ b/docs/src/playground/ExamplePage.tsx
@@ -1,13 +1,27 @@
-import { Grid } from '@mui/material';
+import { Box, Grid } from '@mui/material';
 
 import AppBar from './components/AppBar';
 import Sidebar from './components/Sidebar';
+import StockPriceFooter from './components/StockPriceFooter';
 
 export default function ExamplePage() {
   return (
     <Grid container columns={{ xs: 2, sm: 4, md: 8, lg: 12 }}>
       <Grid item xs={12} md={1}>
         <AppBar />
+      </Grid>
+      <Grid item md={8}>
+        <Box
+          display={'flex'}
+          flexDirection={'column'}
+          height={'100vh'}
+          justifyContent={'flex-end'}
+        >
+          <Box></Box>
+          <Box>
+            <StockPriceFooter />
+          </Box>
+        </Box>
       </Grid>
       <Grid item md={3}>
         <Sidebar />

--- a/docs/src/playground/ExamplePage.tsx
+++ b/docs/src/playground/ExamplePage.tsx
@@ -1,8 +1,7 @@
-import { Box, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 
 import AppBar from './components/AppBar';
 import Sidebar from './components/Sidebar';
-import StockPriceFooter from './components/StockPriceFooter';
 
 export default function ExamplePage() {
   return (
@@ -10,7 +9,9 @@ export default function ExamplePage() {
       <Grid item xs={12} md={1}>
         <AppBar />
       </Grid>
-      <Grid item md={8}>
+      {/* This is just a test of StockerPriceFooter now, later based on the overall layout and the figma design, 
+      it will be modified to fit the whole page  */}
+      {/* <Grid item md={8}>
         <Box
           display={'flex'}
           flexDirection={'column'}
@@ -22,7 +23,7 @@ export default function ExamplePage() {
             <StockPriceFooter />
           </Box>
         </Box>
-      </Grid>
+      </Grid> */}
       <Grid item md={3}>
         <Sidebar />
       </Grid>

--- a/docs/src/playground/components/StockPriceFooter.tsx
+++ b/docs/src/playground/components/StockPriceFooter.tsx
@@ -1,7 +1,8 @@
-import { Box, Divider, useMediaQuery } from '@mui/material';
+import { Box, Divider, useMediaQuery, useTheme } from '@mui/material';
 import { IndexTickers } from '@ui-kit-2022/components';
 const StockPriceFooter = () => {
-  const matches = useMediaQuery('(min-width:830px)');
+  const theme = useTheme();
+  const matches = useMediaQuery(theme.breakpoints.up('md'));
   const isSmallScreen = useMediaQuery('(max-width: 440px)');
   return (
     <>
@@ -9,7 +10,7 @@ const StockPriceFooter = () => {
         <Divider orientation="horizontal" sx={{ width: '100%' }} />
       </Box>
       <Box
-        pt={2}
+        py={2}
         width={'100%'}
         display={'flex'}
         justifyContent={matches ? 'flex-start' : 'center'}

--- a/docs/src/playground/components/StockPriceFooter.tsx
+++ b/docs/src/playground/components/StockPriceFooter.tsx
@@ -1,7 +1,6 @@
 import { Box, Divider, useMediaQuery } from '@mui/material';
 import { IndexTickers } from '@ui-kit-2022/components';
-
-const TickerBar: React.FC = () => {
+const StockPriceFooter = () => {
   const matches = useMediaQuery('(min-width:830px)');
   const isSmallScreen = useMediaQuery('(max-width: 440px)');
   return (
@@ -40,4 +39,4 @@ const TickerBar: React.FC = () => {
   );
 };
 
-export default TickerBar;
+export default StockPriceFooter;


### PR DESCRIPTION
Currently, I just created `StockerPriceFooter` in the playground component,  later based on the overall responsive layout and the Figma design, it will be modified to fit the whole page.