### PR TITLE
Playground stock page layout with graph, statistics, and ticker bar

### DIFF
--- a/docs/src/playground/ExamplePage.tsx
+++ b/docs/src/playground/ExamplePage.tsx
@@ -1,32 +1,109 @@
-import { Grid } from '@mui/material';
+import { Box, Button, ButtonGroup, Divider, Theme, Typography } from '@mui/material';
+import { Graph, Icon } from '@ui-kit-2022/components';
 
 import AppBar from './components/AppBar';
+import KeyStatistics from './components/KeyStatistics';
 import Sidebar from './components/Sidebar';
+import StockPriceFooter from './components/StockPriceFooter';
 
-export default function ExamplePage() {
+const keyStats = {
+  open: '-',
+  high: '-',
+  low: '-',
+  close: '-',
+  dayRange: '-',
+  yearRange: '-',
+  marketCap: '-',
+  p2eRatio: '-',
+  dividendYield: '-',
+  eps: '-',
+  volume: '-',
+  totalAverageVolume: '-',
+};
+
+const styles = {
+  footer: ({ palette }: Theme) => ({
+    position: 'sticky',
+    bottom: 0,
+    backgroundColor: { light: 'paper.white', dark: 'paper.black' }[palette.mode],
+  }),
+  container: ({ breakpoints }: Theme) => ({
+    display: 'flex',
+    minHeight: '100vh',
+    [breakpoints.down('lg')]: {
+      flexDirection: 'column',
+    },
+  }),
+  sidebar: ({ breakpoints }: Theme) => ({
+    flex: 1,
+    overflow: 'hidden',
+    [breakpoints.up('md')]: {
+      maxWidth: '400px',
+    },
+  }),
+  content: ({ breakpoints }: Theme) => ({
+    display: 'flex',
+    flex: 1,
+    minWidth: 0,
+    [breakpoints.down('md')]: {
+      flexDirection: 'column',
+    },
+  }),
+};
+
+type PartialNumberType = number | undefined;
+
+export interface ExamplePageProps {
+  graphProps: {
+    yLabelStep?: number;
+    xLabelStep?: number;
+    labels: string[];
+    data: PartialNumberType[][];
+    previousData?: number;
+  };
+}
+
+export default function ExamplePage({ graphProps }: ExamplePageProps) {
   return (
-    <Grid container columns={{ xs: 2, sm: 4, md: 8, lg: 12 }}>
-      <Grid item xs={12} md={1}>
+    <Box sx={styles.container}>
+      <Box>
         <AppBar />
-      </Grid>
-      {/* This is just a test of StockerPriceFooter now, later based on the overall layout and the figma design, 
-      it will be modified to fit the whole page  */}
-      {/* <Grid item md={8}>
-        <Box
-          display={'flex'}
-          flexDirection={'column'}
-          height={'100vh'}
-          justifyContent={'flex-end'}
-        >
-          <Box></Box>
+      </Box>
+      <Box sx={styles.content}>
+        <Box flex="2" display="flex" flexDirection="column" px={4} sx={{ minWidth: 0 }}>
+          <Box mt={6}>
+            <Typography variant="h3" sx={{ p: 2 }}>
+              AAPL - Apple Inc.
+            </Typography>
+            <Divider orientation="horizontal" />
+          </Box>
           <Box>
+            <Box py={4} display="flex" justifyContent="flex-end" gap={5}>
+              <ButtonGroup variant="primary">
+                {['1D', '5D', '1M', '3M', '6M', 'YTD', '1Y', '5Y', 'All'].map((label) => (
+                  <Button key={label}>{label}</Button>
+                ))}
+              </ButtonGroup>
+              <ButtonGroup variant="primary">
+                <Button>
+                  <Icon.Line />
+                  <Icon.ChevronDown />
+                </Button>
+              </ButtonGroup>
+            </Box>
+            <Graph {...graphProps} />
+          </Box>
+          <Box flex="1 0 auto" my={2}>
+            <KeyStatistics {...keyStats} />
+          </Box>
+          <Box sx={styles.footer}>
             <StockPriceFooter />
           </Box>
         </Box>
-      </Grid> */}
-      <Grid item md={3}>
-        <Sidebar />
-      </Grid>
-    </Grid>
+        <Box sx={styles.sidebar}>
+          <Sidebar />
+        </Box>
+      </Box>
+    </Box>
   );
 }

--- a/docs/src/playground/StocksPage.stories.tsx
+++ b/docs/src/playground/StocksPage.stories.tsx
@@ -1,12 +1,46 @@
-import { ComponentMeta } from '@storybook/react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import Perlin from '../utils/perlin';
 import ExamplePage from './ExamplePage';
+
+const perlin = new Perlin();
+let y = 0.008;
+
+const labels = Array(24 * 60)
+  .fill(0)
+  .map((_, i) => {
+    return (~~(i / 60) + ':0' + Math.round(60 * ((i / 60) % 1))).replace(
+      /\d(\d\d)/g,
+      '$1',
+    );
+  })
+  .filter((time) => {
+    const [hour, minute] = time.split(':');
+    return (
+      ['9', '10', '11', '12', '13', '14', '15'].includes(hour) ||
+      (hour === '16' && minute === '00')
+    );
+  });
 
 export default {
   title: 'Playground',
   component: ExamplePage,
 } as ComponentMeta<typeof ExamplePage>;
 
-const Template = () => <ExamplePage />;
+const Template: ComponentStory<typeof ExamplePage> = (args) => <ExamplePage {...args} />;
 
 export const StocksPage = Template.bind({});
+StocksPage.args = {
+  graphProps: {
+    yLabelStep: 50,
+    xLabelStep: 60,
+    labels,
+    data: [
+      labels.map(() => {
+        y += 0.008;
+        return perlin.get(1, y) * 300 + 200;
+      }),
+    ],
+    previousData: Math.random() * 150,
+  },
+};

--- a/docs/src/playground/components/AppBar.tsx
+++ b/docs/src/playground/components/AppBar.tsx
@@ -15,20 +15,22 @@ const AppBar = () => {
   const appBarStyling = {
     display: 'flex',
     justifyContent: 'center',
+    position: 'sticky',
+    top: 0,
     background:
       theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[100],
     width: '129px',
-    height: '100%',
-    [theme.breakpoints.down('md')]: {
+    minHeight: '100vh',
+    [theme.breakpoints.down('lg')]: {
       width: '100%',
-      height: 'min-content',
-      padding: `${theme.spacing(5)} 0`,
+      minHeight: 'min-content',
+      padding: `${theme.spacing(4)} 0`,
     },
   };
 
   return (
     <Box sx={{ ...appBarStyling }}>
-      {useMediaQuery(theme.breakpoints.up('md')) ? (
+      {useMediaQuery(theme.breakpoints.up('lg')) ? (
         <Box sx={{ ...logoContainerStyling }}>
           <Logo variant="large" />
           <LogoText width={63} height={23} />

--- a/docs/src/playground/components/KeyStatistics.tsx
+++ b/docs/src/playground/components/KeyStatistics.tsx
@@ -1,0 +1,81 @@
+import { Box, Table, TableCell, TableRow, Theme, Typography } from '@mui/material';
+
+export interface Stats {
+  open: string;
+  close: string;
+  high: string;
+  low: string;
+  dayRange: string;
+  yearRange: string;
+  marketCap: string;
+  p2eRatio: string;
+  dividendYield: string;
+  eps: string;
+  volume: string;
+  totalAverageVolume: string;
+}
+
+const labels = new Map([
+  ['open', 'Open'],
+  ['high', 'High'],
+  ['low', 'Low'],
+  ['close', 'Previous Close'],
+  ['dayRange', 'Day Range'],
+  ['yearRange', '52-Week Range'],
+  ['marketCap', 'Market Cap'],
+  ['p2eRatio', 'P/E Ratio'],
+  ['dividendYield', 'Dividend Yield'],
+  ['eps', 'Earnings Per Share'],
+  ['volume', 'Volume'],
+  ['totalAverageVolume', 'Total Avg. Volume'],
+]);
+
+interface StatRowProps {
+  name: keyof Stats;
+  value: string;
+}
+
+const renderStatRow = (stats: Stats, name: keyof Stats) => (
+  <TableRow key={name}>
+    <TableCell component="th" scope="row">
+      {labels.get(name)}
+    </TableCell>
+    <TableCell align="right">{stats[name]}</TableCell>
+  </TableRow>
+);
+
+const styles = {
+  content: ({ breakpoints }: Theme) => ({
+    display: 'flex',
+    gap: 5,
+    mb: 5,
+    [breakpoints.down('md')]: {
+      flexDirection: 'column',
+    },
+  }),
+};
+
+const KeyStatistics = (props: Stats) => (
+  <>
+    <Typography variant="h4" my={5}>
+      Key Statistics
+    </Typography>
+    <Box display="flex" gap={5} mb={5} sx={styles.content}>
+      <Table>
+        {(['open', 'high', 'low', 'close'] as const).map(renderStatRow.bind(this, props))}
+      </Table>
+      <Table>
+        {(['dayRange', 'yearRange', 'marketCap', 'p2eRatio'] as const).map(
+          renderStatRow.bind(this, props),
+        )}
+      </Table>
+      <Table>
+        {(['dividendYield', 'eps', 'volume', 'totalAverageVolume'] as const).map(
+          renderStatRow.bind(this, props),
+        )}
+      </Table>
+    </Box>
+  </>
+);
+
+export default KeyStatistics;

--- a/docs/src/playground/components/Sidebar.tsx
+++ b/docs/src/playground/components/Sidebar.tsx
@@ -8,9 +8,7 @@ export default function Sidebar() {
   const isTiny = useMediaQuery('(max-width: 375px)');
 
   const containerStyling = {
-    maxHeight: '100vh',
-    overflowY: 'scroll',
-    overflowX: 'hidden',
+    minHeight: '100%',
     padding: `${theme.spacing(5)} ${theme.spacing(6)}`,
     backgroundColor:
       theme.palette.mode === 'dark' ? theme.palette.grey[800] : theme.palette.grey[100],

--- a/docs/src/playground/components/StockPriceFooter.tsx
+++ b/docs/src/playground/components/StockPriceFooter.tsx
@@ -6,7 +6,7 @@ const StockPriceFooter = () => {
   const isSmallScreen = useMediaQuery('(max-width: 440px)');
   return (
     <>
-      <Box px={isSmallScreen ? 2 : 4}>
+      <Box>
         <Divider orientation="horizontal" sx={{ width: '100%' }} />
       </Box>
       <Box


### PR DESCRIPTION
<img width="1516" alt="Screen Shot 2022-12-02 at 1 00 52 PM" src="https://user-images.githubusercontent.com/114107223/205356547-73a45386-692e-4e5a-8ea4-95a8b0679c01.png">
<img width="414" alt="Screen Shot 2022-12-02 at 1 01 23 PM" src="https://user-images.githubusercontent.com/114107223/205356734-6bbfc38e-3052-44f9-9719-ed4d647ffdf6.png">
