### PR TITLE
Fix chrome border issue

### DIFF
--- a/packages/ui-kit-theme/src/overrides/MuiTable.ts
+++ b/packages/ui-kit-theme/src/overrides/MuiTable.ts
@@ -2,6 +2,9 @@ import { Theme } from '@mui/material';
 export default {
   styleOverrides: {
     root: ({ theme }: { theme: Theme }) => ({
+      '&.MuiTable-root': {
+        borderCollapse: 'separate',
+      },
       ' * td, * th': {
         padding: '8px',
         verticalAlign: 'top',


### PR DESCRIPTION
It seems that the chrome border issue was caused by `border-collapse` property. After the value was changed from `Collapse `to `Separate`, the issue was gone.

![image](https://user-images.githubusercontent.com/56696843/205373222-faa97f0a-3212-4aec-82fb-e3ea22bfa608.png)
