### PR TITLE
Fixed error in Release GH workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky install",
     "clean": "rm -r ./dist; yarn workspaces foreach run clean",
     "release": "yarn build-lib && yarn changeset publish",
-    "version": "yarn changeset version && yarn",
+    "version": "yarn changeset version && yarn --mode=update-lockfile",
     "test:unit": "yarn jest"
   },
   "devDependencies": {


### PR DESCRIPTION
I needed to explicitly tell yarn to update the lockfile to ignore it's immutability check. I'm not sure why this didn't cause a failure the last time this script ran, but this should ensure it behaves as expected.